### PR TITLE
Add makefile to automate contract generation

### DIFF
--- a/go/Makefile
+++ b/go/Makefile
@@ -1,0 +1,20 @@
+.PHONY: all clean go-generate make-schemas
+SCHEMAS = ../schema
+
+all: go-generate make-schemas
+
+go-generate: $(SCHEMAS)/*.json
+	for file in $^; do \
+		schema_name=$$(echo $${file} | cut -d'.' -f 7 | sed -r 's/([A-Z])/_\L\1/g' | sed 's/^_//' ); \
+		go run cmd/trento-contracts-generator/main.go -fileName $${schema_name} $${file}; \
+	done
+
+add-schema:
+	cat $(SCHEMAS)/schema.json.example | envsubst > $(SCHEMAS)/trento.$(project).v$(version).$(source).$(factname).schema.json
+
+make-schemas:
+	cp $(SCHEMAS)/*.json ./pkg/validator/schemas/
+
+clean:
+	rm -f ./pkg/validator/schemas/*.json
+	rm -f ./pkg/gen/entities/*.go

--- a/schema/schema.json.example
+++ b/schema/schema.json.example
@@ -1,0 +1,5 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "title": "${factname}V${version}"
+}


### PR DESCRIPTION
This PR adds a simple makefile that allows to:
 - `make go-generate`: Generate the relevant go code from the schema directory
 - `make add-schema`: Add a new blank schema from the template, e.g.:
    `make add-schema source=wanda version=1 project=checks factname=FactBlabla`
 - `make make-schemas`: Copies the relevant schemas to the go pkg directory so it can be embedded in the go module

By using `make all` both `go-generate` and `make-schemas` will be called.