### PR TITLE
Add basic CI to check for missing contracts

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,25 @@
+name: Contracts CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  check-go-contracts:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.18
+      - name: generate contracts
+        run: cd go && make go-generate
+      - name: copy contracts to go path
+        run: cd go && make make-schemas
+      - name: Check for uncommited schema changes
+        run: |
+          git add -N go/
+          git diff --quiet || exit 1 && exit 0
+      - name: Git status
+        run: git status


### PR DESCRIPTION
This PR creates a basic pipeline to build the go contracts based on the contents of the schema directory.

This has mainly two benefits:
 - Adds validation: it will cause a broken / invalid schema to fail the pipeline, preventing us from merging a broken PR
 - Checks for uncommited contracts: If someone forgets to add the generated go contracts to the commit, the pipeline will fail