### PR TITLE
Generate a map out of propertyNames-shaped objects

### DIFF
--- a/elixir/lib/execution_completed_v1.ex
+++ b/elixir/lib/execution_completed_v1.ex
@@ -372,7 +372,7 @@ defmodule Trento.Events.Checks.V1.Wanda.ExecutionCompleted do
                   on_replace: :delete
                 )
               ),
-              nil
+              field(:facts, :map)
             ]
 
             (

--- a/elixir/lib/mix/tasks/generate.ex
+++ b/elixir/lib/mix/tasks/generate.ex
@@ -302,6 +302,19 @@ defmodule Mix.Tasks.Contracts.Generate do
     end
   end
 
+  def get_field(
+        {k,
+         %{
+           "type" => "object",
+           "propertyNames" => _property_names,
+           "patternProperties" => _pattern_properties
+         }}
+      ) do
+    quote do
+      field(unquote(String.to_atom(k)), :map)
+    end
+  end
+
   def get_field({k, %{"type" => "string"}}) do
     quote do
       field(unquote(String.to_atom(k)), :string)


### PR DESCRIPTION
Using `propertyNames` and `patternProperties` should generate a map, we didn't do it. Now we do.