### PR TITLE
Pin protoc gen go

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -2,3 +2,4 @@ elixir 1.13.1-otp-24
 erlang 24.3.4
 golang 1.18.1
 protoc 3.20.1
+protoc-gen-go 1.28.1

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,9 @@
 .PHONY: all go-generate
 
-GO_PATH=$(shell go env GOPATH)
-
 all: go-generate elixir-generate
 
 go-generate: # Generate golang protobuf stubs
 	protoc --experimental_allow_proto3_optional \
-	--plugin $(GO_PATH)/bin/protoc-gen-go \
 	--go_out go/pkg/events/ protobuf/*.proto
 
 elixir-generate: # Generate elixir protobuf stubs

--- a/README.md
+++ b/README.md
@@ -1,1 +1,46 @@
 # Trento Contracts
+
+# How to generate the interfaces
+
+Follow the next steps in order to generate the final code interfaces from the [protobuf definitions](./protobuf/).
+
+## Pre-requirements
+
+- Install [asdf](https://asdf-vm.com/guide/getting-started.html) and add all the needed plugins:
+
+```
+asdf plugin add elixir
+asdf plugin add erlang
+asdf plugin add golang
+asdf plugin add protoc
+asdf plugin add protoc-gen-go
+```
+
+- Define `golang` version to `asdf` to enable `protoc-gen-go` usage. For that, edit `$HOME/.asdf/.tool-versions` and append the next line:
+
+```
+golang 1.18.1
+```
+
+- Install the required tool versions running:
+
+```
+asdf install
+```
+
+- Install and configure `protoc-gen-elixir` running:
+
+```
+mix escript.install hex protobuf
+asdf reshim
+```
+
+## Generate the code
+
+Once all the tools are installed, run the next command to update the final code interfaces:
+
+```
+make
+```
+
+In order to make the last command work, `protoc-gen-go` and `protoc-gen-elixir` must be available in your PATH system variable (they are if they are installed using the previously explained `asdf` option).


### PR DESCRIPTION
Use the already available `protoc-gen-go` asdf plugin: https://github.com/pbr0ck3r/asdf-protoc-gen-go
This is the official one, even though it doesn't have even a star. It is included in the asdf official catalog.

Besides that, I have included a basic step-by-step guide explaining how to install everything from scratch.
I would appreciate if somebody that doesn't have the environment ready to give a try to see if it works. Mine was half configured, so it wasn't the best testing env.