### PR TITLE
Run CI `test` step on different versions of Elixir & OTP

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,13 +6,22 @@ on:
   pull_request:
 
 env:
-  ELIXIR_VERSION: 1.13.1
-  OTP_VERSION: 24
+  ELIXIR_VERSION: 1.14.3
+  OTP_VERSION: 25
+  ELIXIR_VERSION_OBS: 1.13.4
+  OTP_VERSION_OBS: 22
 
 jobs:
   elixir-deps:
-    name: Elixir dependencies
+    name: Elixir dependencies (Elixir ${{ matrix.elixir }}, OTP ${{ matrix.otp }})
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        include:
+          - elixir: 1.14.3
+            otp: 25
+          - elixir: 1.13.4
+            otp: 22
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.10.0
@@ -27,8 +36,8 @@ jobs:
       - name: Setup
         uses: erlef/setup-beam@v1
         with:
-          elixir-version: ${{ env.ELIXIR_VERSION }}
-          otp-version: ${{ env.OTP_VERSION }}
+          elixir-version: ${{ matrix.elixir }}
+          otp-version: ${{ matrix.otp }}
         env:
           ImageOS: ubuntu20
 
@@ -40,7 +49,7 @@ jobs:
             elixir/deps
             elixir/_build/test
             elixir/priv/plts
-          key: ${{ runner.os }}-${{ env.OTP_VERSION }}-${{ env.ELIXIR_VERSION }}-${{ hashFiles('elixir/mix.lock') }}
+          key: ${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('elixir/mix.lock') }}
 
       - name: Install Dependencies
         if: steps.mix-cache.outputs.cache-hit != 'true'
@@ -141,7 +150,7 @@ jobs:
         run: echo "$HOME/.mix/escripts" >> $GITHUB_PATH
       - name: generate contracts
         run: make elixir-generate
-      - name: Check for uncommited schema changes
+      - name: Check for uncommitted schema changes
         run: |
           git add -N elixir/
           git diff
@@ -168,7 +177,7 @@ jobs:
         run: go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.28
       - name: generate contracts
         run: make go-generate
-      - name: Check for uncommited schema changes
+      - name: Check for uncommitted schema changes
         run: |
           git add -N go/
           git diff
@@ -201,9 +210,16 @@ jobs:
         run: go mod download && go test ./...
 
   test-elixir:
-    name: Elixir test
+    name: Elixir test (Elixir ${{ matrix.elixir }}, OTP ${{ matrix.otp }})
     needs: [elixir-deps, check-elixir-contracts]
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        include:
+          - elixir: 1.14.3
+            otp: 25
+          - elixir: 1.13.4
+            otp: 22
 
     steps:
       - name: Cancel Previous Runs
@@ -219,8 +235,8 @@ jobs:
       - name: Setup
         uses: erlef/setup-beam@v1
         with:
-          elixir-version: ${{ env.ELIXIR_VERSION }}
-          otp-version: ${{ env.OTP_VERSION }}
+          elixir-version: ${{ matrix.elixir }}
+          otp-version: ${{ matrix.otp }}
 
       - name: Retrieve Cached Dependencies
         uses: actions/cache@v3
@@ -230,7 +246,7 @@ jobs:
             elixir/deps
             elixir/_build/test
             elixir/priv/plts
-          key: ${{ runner.os }}-${{ env.OTP_VERSION }}-${{ env.ELIXIR_VERSION }}-${{ hashFiles('elixir/mix.lock') }}
+          key: ${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('elixir/mix.lock') }}
 
       - name: Run elixir test
         working-directory: elixir

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,5 +1,5 @@
-elixir 1.13.1-otp-24
-erlang 24.3.4
+elixir 1.14.3-otp-25
+erlang 25.2.2
 golang 1.18.1
 protoc 3.20.1
 protoc-gen-go 1.28.1


### PR DESCRIPTION
This change aims to run the test step of the CI against both the versions of Elixir + OTP that are packaged with OBS/IBS and the one used for development.

Note that this change will need to be propagated through the other repos that use Elixir also.