### PR TITLE
Events expiration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,10 @@ jobs:
         include:
           - elixir: 1.15.7
             otp: 26
-          - elixir: 1.14.3
-            otp: 25
-          - elixir: 1.13.4
-            otp: 22
+          - elixir: 1.15.8
+            otp: 26
+          - elixir: 1.16.0
+            otp: 26
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.12.1
@@ -216,10 +216,12 @@ jobs:
     strategy:
       matrix:
         include:
-          - elixir: 1.14.3
-            otp: 25
-          - elixir: 1.13.4
-            otp: 22
+          - elixir: 1.15.7
+            otp: 26
+          - elixir: 1.15.8
+            otp: 26
+          - elixir: 1.16.0
+            otp: 26
 
     steps:
       - name: Cancel Previous Runs

--- a/elixir/lib/contracts.ex
+++ b/elixir/lib/contracts.ex
@@ -5,6 +5,8 @@ defmodule Trento.Contracts do
 
   require Logger
 
+  @default_expiration_window_minutes 5
+
   @doc """
   Return the content type of contracts
   """
@@ -25,7 +27,16 @@ defmodule Trento.Contracts do
         DateTime.utc_now()
       )
 
+    expiration =
+      Keyword.get(
+        opts,
+        :expiration,
+        DateTime.add(time, @default_expiration_window_minutes, :minute)
+      )
+
     time_attr = %Google.Protobuf.Timestamp{seconds: time |> DateTime.to_unix()}
+    expiration_attr = %Google.Protobuf.Timestamp{seconds: expiration |> DateTime.to_unix()}
+
     data = Protobuf.Encoder.encode(struct)
 
     cloud_event = %CloudEvents.CloudEvent{
@@ -34,7 +45,10 @@ defmodule Trento.Contracts do
       type: get_type(mod),
       id: id,
       attributes: %{
-        "time" => %CloudEvents.CloudEventAttributeValue{attr: {:ce_timestamp, time_attr}}
+        "time" => %CloudEvents.CloudEventAttributeValue{attr: {:ce_timestamp, time_attr}},
+        "expiration" => %CloudEvents.CloudEventAttributeValue{
+          attr: {:ce_timestamp, expiration_attr}
+        }
       },
       source: source
     }
@@ -52,14 +66,14 @@ defmodule Trento.Contracts do
           | {:error, :event_not_found}
   def from_event(value) do
     try do
-      case CloudEvents.CloudEvent.decode(value) do
-        %{type: type, data: {:proto_data, %Google.Protobuf.Any{value: data}}} ->
-          decode(type, data)
+      case decode_and_validate(value) do
+        {:ok, event} ->
+          {:ok, event}
 
-        event ->
-          Logger.error("Invalid cloud event: #{inspect(event)}")
+        {:error, reason} ->
+          Logger.error("Invalid trento event: #{inspect(reason)}")
 
-          {:error, :invalid_envelope}
+          {:error, reason}
       end
     rescue
       error ->
@@ -69,7 +83,30 @@ defmodule Trento.Contracts do
     end
   end
 
-  defp decode(type, data) do
+  defp decode_and_validate(value) do
+    with {:ok, event_type, attributes, event_data} <- extract_event(value),
+         {:ok, decoded_event} <- decode_trento_event(event_type, event_data),
+         {:ok, _} <- validate_event_expiration(attributes) do
+      {:ok, decoded_event}
+    end
+  end
+
+  defp extract_event(value) do
+    case CloudEvents.CloudEvent.decode(value) do
+      %{
+        type: event_type,
+        attributes: attributes,
+        data: {:proto_data, %Google.Protobuf.Any{value: event_data}}
+      } ->
+        {:ok, event_type, attributes, event_data}
+
+      invalid_event ->
+        Logger.error("Invalid cloud event: #{inspect(invalid_event)}")
+        {:error, :invalid_envelope}
+    end
+  end
+
+  defp decode_trento_event(type, data) do
     try do
       module_name = Macro.camelize(type)
       module = Module.safe_concat([module_name])
@@ -84,5 +121,23 @@ defmodule Trento.Contracts do
     mod
     |> Atom.to_string()
     |> String.replace("Elixir.", "")
+  end
+
+  defp validate_event_expiration(%{
+         "expiration" => %CloudEvents.CloudEventAttributeValue{
+           attr: {:ce_timestamp, %Google.Protobuf.Timestamp{seconds: unix_expiration}}
+         }
+       }) do
+    expiration = DateTime.from_unix!(unix_expiration)
+
+    if DateTime.after?(expiration, DateTime.utc_now()) do
+      {:ok, expiration}
+    else
+      {:error, :event_expired}
+    end
+  end
+
+  defp validate_event_expiration(_) do
+    {:error, :expiration_attribute_not_found}
   end
 end

--- a/elixir/lib/contracts.ex
+++ b/elixir/lib/contracts.ex
@@ -93,7 +93,7 @@ defmodule Trento.Contracts do
   defp decode_and_validate(value, validate_expiration) do
     with {:ok, event_type, attributes, event_data} <- extract_event(value),
          {:ok, decoded_event} <- decode_trento_event(event_type, event_data),
-         :ok <- maybe_validate_expiration(attributes, !validate_expiration) do
+         :ok <- maybe_validate_expiration(attributes, validate_expiration) do
       {:ok, decoded_event}
     end
   end
@@ -130,7 +130,7 @@ defmodule Trento.Contracts do
     |> String.replace("Elixir.", "")
   end
 
-  defp maybe_validate_expiration(_payload, true), do: :ok
+  defp maybe_validate_expiration(_payload, false), do: :ok
 
   defp maybe_validate_expiration(
          %{
@@ -138,7 +138,7 @@ defmodule Trento.Contracts do
              attr: {:ce_timestamp, %Google.Protobuf.Timestamp{seconds: unix_expiration}}
            }
          },
-         _skip_validation
+         true
        ) do
     expiration = DateTime.from_unix!(unix_expiration)
 

--- a/elixir/lib/protobuf/cloudevent.pb.ex
+++ b/elixir/lib/protobuf/cloudevent.pb.ex
@@ -1,7 +1,7 @@
 defmodule CloudEvents.CloudEvent.AttributesEntry do
   @moduledoc false
 
-  use Protobuf, map: true, protoc_gen_elixir_version: "0.14.0", syntax: :proto3
+  use Protobuf, map: true, protoc_gen_elixir_version: "0.14.1", syntax: :proto3
 
   field :key, 1, type: :string
   field :value, 2, type: CloudEvents.CloudEventAttributeValue
@@ -10,7 +10,7 @@ end
 defmodule CloudEvents.CloudEvent do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto3
+  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto3
 
   oneof :data, 0
 
@@ -27,7 +27,7 @@ end
 defmodule CloudEvents.CloudEventAttributeValue do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto3
+  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto3
 
   oneof :attr, 0
 

--- a/elixir/lib/protobuf/execution_completed.pb.ex
+++ b/elixir/lib/protobuf/execution_completed.pb.ex
@@ -1,7 +1,7 @@
 defmodule Trento.Checks.V1.Result do
   @moduledoc false
 
-  use Protobuf, enum: true, protoc_gen_elixir_version: "0.14.0", syntax: :proto3
+  use Protobuf, enum: true, protoc_gen_elixir_version: "0.14.1", syntax: :proto3
 
   field :PASSING, 0
   field :WARNING, 1
@@ -11,7 +11,7 @@ end
 defmodule Trento.Checks.V1.ExecutionCompleted do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto3
+  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto3
 
   field :execution_id, 1, type: :string, json_name: "executionId"
   field :group_id, 2, type: :string, json_name: "groupId"

--- a/elixir/lib/protobuf/execution_requested.pb.ex
+++ b/elixir/lib/protobuf/execution_requested.pb.ex
@@ -1,7 +1,7 @@
 defmodule Trento.Checks.V1.ExecutionRequested.EnvEntry do
   @moduledoc false
 
-  use Protobuf, map: true, protoc_gen_elixir_version: "0.14.0", syntax: :proto3
+  use Protobuf, map: true, protoc_gen_elixir_version: "0.14.1", syntax: :proto3
 
   field :key, 1, type: :string
   field :value, 2, type: Google.Protobuf.Value
@@ -10,7 +10,7 @@ end
 defmodule Trento.Checks.V1.ExecutionRequested do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto3
+  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto3
 
   field :execution_id, 1, type: :string, json_name: "executionId"
   field :group_id, 2, type: :string, json_name: "groupId"

--- a/elixir/lib/protobuf/execution_started.pb.ex
+++ b/elixir/lib/protobuf/execution_started.pb.ex
@@ -1,7 +1,7 @@
 defmodule Trento.Checks.V1.ExecutionStarted do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto3
+  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto3
 
   field :execution_id, 1, type: :string, json_name: "executionId"
   field :group_id, 2, type: :string, json_name: "groupId"

--- a/elixir/lib/protobuf/facts_gathered.pb.ex
+++ b/elixir/lib/protobuf/facts_gathered.pb.ex
@@ -1,7 +1,7 @@
 defmodule Trento.Checks.V1.FactError do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto3
+  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto3
 
   field :message, 1, type: :string
   field :type, 2, type: :string
@@ -10,7 +10,7 @@ end
 defmodule Trento.Checks.V1.Fact do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto3
+  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto3
 
   oneof :fact_value, 0
 
@@ -23,7 +23,7 @@ end
 defmodule Trento.Checks.V1.FactsGathered do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto3
+  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto3
 
   field :execution_id, 1, type: :string, json_name: "executionId"
   field :group_id, 2, type: :string, json_name: "groupId"

--- a/elixir/lib/protobuf/facts_gathering_requested.pb.ex
+++ b/elixir/lib/protobuf/facts_gathering_requested.pb.ex
@@ -1,7 +1,7 @@
 defmodule Trento.Checks.V1.FactRequest do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto3
+  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto3
 
   field :check_id, 1, type: :string, json_name: "checkId"
   field :name, 2, type: :string
@@ -12,7 +12,7 @@ end
 defmodule Trento.Checks.V1.FactsGatheringRequestedTarget do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto3
+  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto3
 
   field :agent_id, 1, type: :string, json_name: "agentId"
 
@@ -25,7 +25,7 @@ end
 defmodule Trento.Checks.V1.FactsGatheringRequested do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto3
+  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto3
 
   field :execution_id, 1, type: :string, json_name: "executionId"
   field :group_id, 2, type: :string, json_name: "groupId"

--- a/elixir/lib/protobuf/operation_completed.pb.ex
+++ b/elixir/lib/protobuf/operation_completed.pb.ex
@@ -1,7 +1,7 @@
 defmodule Trento.Operations.V1.OperationResult do
   @moduledoc false
 
-  use Protobuf, enum: true, protoc_gen_elixir_version: "0.14.0", syntax: :proto3
+  use Protobuf, enum: true, protoc_gen_elixir_version: "0.14.1", syntax: :proto3
 
   field :UPDATED, 0
   field :NOT_UPDATED, 1
@@ -14,7 +14,7 @@ end
 defmodule Trento.Operations.V1.OperationCompleted do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto3
+  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto3
 
   field :operation_id, 1, type: :string, json_name: "operationId"
   field :group_id, 2, type: :string, json_name: "groupId"

--- a/elixir/lib/protobuf/operation_requested.pb.ex
+++ b/elixir/lib/protobuf/operation_requested.pb.ex
@@ -1,7 +1,7 @@
 defmodule Trento.Operations.V1.OperationRequested do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto3
+  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto3
 
   field :operation_id, 1, type: :string, json_name: "operationId"
   field :group_id, 2, type: :string, json_name: "groupId"

--- a/elixir/lib/protobuf/operation_started.pb.ex
+++ b/elixir/lib/protobuf/operation_started.pb.ex
@@ -1,7 +1,7 @@
 defmodule Trento.Operations.V1.OperationStarted do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto3
+  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto3
 
   field :operation_id, 1, type: :string, json_name: "operationId"
   field :group_id, 2, type: :string, json_name: "groupId"

--- a/elixir/lib/protobuf/operation_target.pb.ex
+++ b/elixir/lib/protobuf/operation_target.pb.ex
@@ -1,7 +1,7 @@
 defmodule Trento.Operations.V1.OperationTarget.ArgumentsEntry do
   @moduledoc false
 
-  use Protobuf, map: true, protoc_gen_elixir_version: "0.14.0", syntax: :proto3
+  use Protobuf, map: true, protoc_gen_elixir_version: "0.14.1", syntax: :proto3
 
   field :key, 1, type: :string
   field :value, 2, type: Google.Protobuf.Value
@@ -10,7 +10,7 @@ end
 defmodule Trento.Operations.V1.OperationTarget do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto3
+  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto3
 
   field :agent_id, 1, type: :string, json_name: "agentId"
 

--- a/elixir/lib/protobuf/target.pb.ex
+++ b/elixir/lib/protobuf/target.pb.ex
@@ -1,7 +1,7 @@
 defmodule Trento.Checks.V1.Target do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto3
+  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto3
 
   field :agent_id, 1, type: :string, json_name: "agentId"
   field :checks, 2, repeated: true, type: :string

--- a/elixir/mix.exs
+++ b/elixir/mix.exs
@@ -5,7 +5,7 @@ defmodule Proto.MixProject do
     [
       app: :trento_contracts,
       version: "0.1.0",
-      elixir: "~> 1.13",
+      elixir: "~> 1.15",
       start_permanent: Mix.env() == :prod,
       elixirc_paths: elixirc_paths(Mix.env()),
       deps: deps()

--- a/elixir/test/contracts_test.exs
+++ b/elixir/test/contracts_test.exs
@@ -102,13 +102,13 @@ defmodule Trento.ContractsTest do
       assert {:error, :invalid_envelope} = Trento.Contracts.from_event(event)
     end
 
-    test "should return error if the could not be decoded" do
+    test "should return error if the event could not be decoded" do
       event = <<0, 0>>
 
       assert {:error, :decoding_error} = Trento.Contracts.from_event(event)
     end
 
-    test "should return error if the event type is unknown" do
+    test "should return error if an event type is unknown" do
       cloudevent = %CloudEvent{
         data:
           {:proto_data,

--- a/elixir/test/contracts_test.exs
+++ b/elixir/test/contracts_test.exs
@@ -194,7 +194,7 @@ defmodule Trento.ContractsTest do
         )
 
       assert id == cloudevent_id
-      assert cloudevent_source == "trento"
+      assert cloudevent_source == "https://github.com/trento-project"
       refute time_ts == nil
       refute expiration_ts == nil
 

--- a/elixir/test/contracts_test.exs
+++ b/elixir/test/contracts_test.exs
@@ -1,92 +1,207 @@
 defmodule Trento.ContractsTest do
+  @moduledoc false
   use ExUnit.Case
 
   alias CloudEvents.CloudEvent
 
-  test "should decode to the right struct" do
-    event_id = UUID.uuid4()
-    event = %Test.Event{id: event_id}
+  describe "event decoding" do
+    test "should decode to the right struct when no errors are detected in the event payload" do
+      event_id = UUID.uuid4()
+      event = %Test.Event{id: event_id}
+      time = DateTime.utc_now()
+      expiration = DateTime.add(time, 2, :minute)
+      time_attr = %Google.Protobuf.Timestamp{seconds: time |> DateTime.to_unix()}
+      expiration_attr = %Google.Protobuf.Timestamp{seconds: expiration |> DateTime.to_unix()}
 
-    cloudevent = %CloudEvent{
-      data:
-        {:proto_data,
-         %Google.Protobuf.Any{
-           __unknown_fields__: [],
-           type_url: "test.Event",
-           value: Test.Event.encode(event)
-         }},
-      id: UUID.uuid4(),
-      source: "wandalorian",
-      spec_version: "1.0",
-      type: "test.Event"
-    }
-
-    encoded_cloudevent = CloudEvent.encode(cloudevent)
-
-    assert {:ok, %Test.Event{id: ^event_id}} = Trento.Contracts.from_event(encoded_cloudevent)
-  end
-
-  test "should encode to the right struct" do
-    event = %Test.Event{id: UUID.uuid4()}
-    cloudevent_id = UUID.uuid4()
-    time = DateTime.utc_now()
-    time_attr = %Google.Protobuf.Timestamp{seconds: time |> DateTime.to_unix()}
-
-    cloudevent = %CloudEvent{
-      data:
-        {:proto_data,
-         %Google.Protobuf.Any{
-           __unknown_fields__: [],
-           type_url: "Test.Event",
-           value: Test.Event.encode(event)
-         }},
-      id: cloudevent_id,
-      source: "wandalorian",
-      spec_version: "1.0",
-      type: "Test.Event",
-      attributes: %{
-        "time" => %CloudEvents.CloudEventAttributeValue{attr: {:ce_timestamp, time_attr}}
+      cloudevent = %CloudEvent{
+        data:
+          {:proto_data,
+           %Google.Protobuf.Any{
+             __unknown_fields__: [],
+             type_url: "test.Event",
+             value: Test.Event.encode(event)
+           }},
+        id: UUID.uuid4(),
+        source: "wandalorian",
+        spec_version: "1.0",
+        type: "test.Event",
+        attributes: %{
+          "time" => %CloudEvents.CloudEventAttributeValue{attr: {:ce_timestamp, time_attr}},
+          "expiration" => %CloudEvents.CloudEventAttributeValue{
+            attr: {:ce_timestamp, expiration_attr}
+          }
+        }
       }
-    }
 
-    encoded_cloudevent = CloudEvent.encode(cloudevent)
+      encoded_cloudevent = CloudEvent.encode(cloudevent)
 
-    assert encoded_cloudevent ==
-             Trento.Contracts.to_event(event,
-               id: cloudevent_id,
-               source: "wandalorian",
-               time: time
-             )
+      assert {:ok, %Test.Event{id: ^event_id}} = Trento.Contracts.from_event(encoded_cloudevent)
+    end
+
+    test "should return an error when the event is expired" do
+      event_id = UUID.uuid4()
+      event = %Test.Event{id: event_id}
+      time = DateTime.add(DateTime.utc_now(), -2, :minute)
+      expiration = DateTime.add(time, 1, :minute)
+      time_attr = %Google.Protobuf.Timestamp{seconds: time |> DateTime.to_unix()}
+      expiration_attr = %Google.Protobuf.Timestamp{seconds: expiration |> DateTime.to_unix()}
+
+      cloudevent = %CloudEvent{
+        data:
+          {:proto_data,
+           %Google.Protobuf.Any{
+             __unknown_fields__: [],
+             type_url: "test.Event",
+             value: Test.Event.encode(event)
+           }},
+        id: UUID.uuid4(),
+        source: "wandalorian",
+        spec_version: "1.0",
+        type: "test.Event",
+        attributes: %{
+          "time" => %CloudEvents.CloudEventAttributeValue{attr: {:ce_timestamp, time_attr}},
+          "expiration" => %CloudEvents.CloudEventAttributeValue{
+            attr: {:ce_timestamp, expiration_attr}
+          }
+        }
+      }
+
+      encoded_cloudevent = CloudEvent.encode(cloudevent)
+      assert {:error, :event_expired} = Trento.Contracts.from_event(encoded_cloudevent)
+    end
+
+    test "should return an error when the event does not have the expiration attribute" do
+      event_id = UUID.uuid4()
+      event = %Test.Event{id: event_id}
+      time = DateTime.add(DateTime.utc_now(), -2, :minute)
+      time_attr = %Google.Protobuf.Timestamp{seconds: time |> DateTime.to_unix()}
+
+      cloudevent = %CloudEvent{
+        data:
+          {:proto_data,
+           %Google.Protobuf.Any{
+             __unknown_fields__: [],
+             type_url: "test.Event",
+             value: Test.Event.encode(event)
+           }},
+        id: UUID.uuid4(),
+        source: "wandalorian",
+        spec_version: "1.0",
+        type: "test.Event",
+        attributes: %{
+          "time" => %CloudEvents.CloudEventAttributeValue{attr: {:ce_timestamp, time_attr}}
+        }
+      }
+
+      encoded_cloudevent = CloudEvent.encode(cloudevent)
+
+      assert {:error, :expiration_attribute_not_found} =
+               Trento.Contracts.from_event(encoded_cloudevent)
+    end
+
+    test "should return error if the event is not wrapped in a CloudEvent" do
+      event = Test.Event.encode(%Test.Event{id: UUID.uuid4()})
+
+      assert {:error, :invalid_envelope} = Trento.Contracts.from_event(event)
+    end
+
+    test "should return error if the could not be decoded" do
+      event = <<0, 0>>
+
+      assert {:error, :decoding_error} = Trento.Contracts.from_event(event)
+    end
+
+    test "should return error if the event type is unknown" do
+      cloudevent = %CloudEvent{
+        data:
+          {:proto_data,
+           %Google.Protobuf.Any{
+             __unknown_fields__: [],
+             type_url: "Unknown.Event",
+             value: <<0, 0, 0, 0, 0, 0, 0, 0>>
+           }},
+        id: UUID.uuid4(),
+        source: "wandalorian",
+        spec_version: "1.0",
+        type: "Unknown.Event"
+      }
+
+      assert {:error, :unknown_event} =
+               cloudevent |> CloudEvent.encode() |> Trento.Contracts.from_event()
+    end
   end
 
-  test "should return error if the event is not wrapped in a CloudEvent" do
-    event = Test.Event.encode(%Test.Event{id: UUID.uuid4()})
+  describe "event encoding" do
+    test "should encode to the right struct when all the options are provided" do
+      event = %Test.Event{id: UUID.uuid4()}
+      cloudevent_id = UUID.uuid4()
+      time = DateTime.utc_now()
+      expiration = DateTime.add(time, 3, :minute)
+      time_attr = %Google.Protobuf.Timestamp{seconds: time |> DateTime.to_unix()}
+      expiration_attr = %Google.Protobuf.Timestamp{seconds: expiration |> DateTime.to_unix()}
 
-    assert {:error, :invalid_envelope} = Trento.Contracts.from_event(event)
-  end
+      cloudevent = %CloudEvent{
+        data:
+          {:proto_data,
+           %Google.Protobuf.Any{
+             __unknown_fields__: [],
+             type_url: "Test.Event",
+             value: Test.Event.encode(event)
+           }},
+        id: cloudevent_id,
+        source: "wandalorian",
+        spec_version: "1.0",
+        type: "Test.Event",
+        attributes: %{
+          "time" => %CloudEvents.CloudEventAttributeValue{attr: {:ce_timestamp, time_attr}},
+          "expiration" => %CloudEvents.CloudEventAttributeValue{
+            attr: {:ce_timestamp, expiration_attr}
+          }
+        }
+      }
 
-  test "should return error if the could not be decoded" do
-    event = <<0, 0>>
+      encoded_cloudevent = CloudEvent.encode(cloudevent)
 
-    assert {:error, :decoding_error} = Trento.Contracts.from_event(event)
-  end
+      assert encoded_cloudevent ==
+               Trento.Contracts.to_event(event,
+                 id: cloudevent_id,
+                 source: "wandalorian",
+                 time: time,
+                 expiration: expiration
+               )
+    end
 
-  test "should return error if the event type is unknown" do
-    cloudevent = %CloudEvent{
-      data:
-        {:proto_data,
-         %Google.Protobuf.Any{
-           __unknown_fields__: [],
-           type_url: "Unknown.Event",
-           value: <<0, 0, 0, 0, 0, 0, 0, 0>>
-         }},
-      id: UUID.uuid4(),
-      source: "wandalorian",
-      spec_version: "1.0",
-      type: "Unknown.Event"
-    }
+    test "should encode to the right struct with the defaults, when no options are provided" do
+      event = %Test.Event{id: UUID.uuid4()}
+      id = UUID.uuid4()
 
-    assert {:error, :unknown_event} =
-             cloudevent |> CloudEvent.encode() |> Trento.Contracts.from_event()
+      %{
+        id: cloudevent_id,
+        source: cloudevent_source,
+        attributes: %{
+          "expiration" => %CloudEvents.CloudEventAttributeValue{
+            attr: {:ce_timestamp, %Google.Protobuf.Timestamp{seconds: expiration_ts}}
+          },
+          "time" => %CloudEvents.CloudEventAttributeValue{
+            attr: {:ce_timestamp, %Google.Protobuf.Timestamp{seconds: time_ts}}
+          }
+        }
+      } =
+        CloudEvent.decode(
+          Trento.Contracts.to_event(event,
+            id: id
+          )
+        )
+
+      assert id == cloudevent_id
+      assert cloudevent_source == "trento"
+      refute time_ts == nil
+      refute expiration_ts == nil
+
+      cloudevent_time = DateTime.from_unix!(time_ts)
+      cloudevent_expiration = DateTime.from_unix!(expiration_ts)
+
+      assert cloudevent_expiration == DateTime.add(cloudevent_time, 5, :minute)
+    end
   end
 end

--- a/go/pkg/events/events_test.go
+++ b/go/pkg/events/events_test.go
@@ -140,7 +140,6 @@ func TestFromEvent(t *testing.T) {
 	assert.NoError(t, err)
 
 	now := time.Now()
-	expiration := now.Add(60 * time.Minute)
 
 	ce := events.CloudEvent{
 		Id:          "id",
@@ -154,11 +153,6 @@ func TestFromEvent(t *testing.T) {
 			"time": {
 				Attr: &events.CloudEventAttributeValue_CeTimestamp{
 					CeTimestamp: timestamppb.New(now),
-				},
-			},
-			"expiration": {
-				Attr: &events.CloudEventAttributeValue_CeTimestamp{
-					CeTimestamp: timestamppb.New(expiration),
 				},
 			},
 		},
@@ -230,7 +224,7 @@ func TestFromEventExpiredEventError(t *testing.T) {
 
 	rawEvent, err := proto.Marshal(&ce)
 	assert.NoError(t, err)
-	err = events.FromEvent(rawEvent, &decodedEvent)
+	err = events.FromEvent(rawEvent, &decodedEvent, events.WithExpirationCheck())
 	assert.ErrorIs(t, err, events.ErrEventExpired)
 }
 
@@ -279,7 +273,7 @@ func TestFromEventNoExpirationSetError(t *testing.T) {
 
 	rawEvent, err := proto.Marshal(&ce)
 	assert.NoError(t, err)
-	err = events.FromEvent(rawEvent, &decodedEvent)
+	err = events.FromEvent(rawEvent, &decodedEvent, events.WithExpirationCheck())
 	assert.ErrorIs(t, err, events.ErrExpirationNotFound)
 }
 
@@ -331,6 +325,6 @@ func TestFromEventExpirationMalformedError(t *testing.T) {
 
 	rawEvent, err := proto.Marshal(&ce)
 	assert.NoError(t, err)
-	err = events.FromEvent(rawEvent, &decodedEvent)
+	err = events.FromEvent(rawEvent, &decodedEvent, events.WithExpirationCheck())
 	assert.ErrorIs(t, err, events.ErrExpirationAttributeMalformed)
 }

--- a/go/pkg/events/events_test.go
+++ b/go/pkg/events/events_test.go
@@ -32,13 +32,20 @@ func TestToEvent(t *testing.T) {
 
 	id := "id"
 	source := "wandalorian"
-	time := time.Now()
+	now := time.Now()
+	expiration := now.Add(2 * time.Minute)
 
 	data, err := anypb.New(&event)
 
-	attr := events.CloudEventAttributeValue{
+	timeAttr := events.CloudEventAttributeValue{
 		Attr: &events.CloudEventAttributeValue_CeTimestamp{
-			CeTimestamp: timestamppb.New(time),
+			CeTimestamp: timestamppb.New(now),
+		},
+	}
+
+	expireAttr := events.CloudEventAttributeValue{
+		Attr: &events.CloudEventAttributeValue_CeTimestamp{
+			CeTimestamp: timestamppb.New(expiration),
 		},
 	}
 
@@ -52,14 +59,21 @@ func TestToEvent(t *testing.T) {
 			ProtoData: data,
 		},
 		Attributes: map[string]*events.CloudEventAttributeValue{
-			"time": &attr,
+			"time":       &timeAttr,
+			"expiration": &expireAttr,
 		},
 	}
 
 	rawCe, err := proto.Marshal(&ce)
 	assert.NoError(t, err)
 
-	encodedEvent, err := events.ToEvent(&event, events.WithID(id), events.WithSource(source), events.WithTime(time))
+	encodedEvent, err := events.ToEvent(
+		&event,
+		events.WithID(id),
+		events.WithSource(source),
+		events.WithTime(now),
+		events.WithExpiration(expiration),
+	)
 	assert.NoError(t, err)
 
 	assert.EqualValues(t, rawCe, encodedEvent)
@@ -84,8 +98,22 @@ func TestToEventWithDefaults(t *testing.T) {
 		},
 	}
 
-	_, err := events.ToEvent(&event)
+	rawEvent, err := events.ToEvent(&event)
 	assert.NoError(t, err)
+
+	var expectedCe events.CloudEvent
+	err = proto.Unmarshal(rawEvent, &expectedCe)
+	assert.NoError(t, err)
+
+	expectedExpiration := expectedCe.GetAttributes()["expiration"].GetCeTimestamp().AsTime()
+	expectedTime := expectedCe.GetAttributes()["time"].GetCeTimestamp().AsTime()
+	expectedSource := expectedCe.Source
+	expectedID := expectedCe.Id
+
+	assert.NotNil(t, expectedExpiration)
+	assert.NotNil(t, expectedTime)
+	assert.Equal(t, "https://github.com/trento-project", expectedSource)
+	assert.NotEmpty(t, expectedID)
 }
 
 func TestFromEvent(t *testing.T) {
@@ -110,6 +138,10 @@ func TestFromEvent(t *testing.T) {
 	data, err := anypb.New(&event)
 
 	assert.NoError(t, err)
+
+	now := time.Now()
+	expiration := now.Add(60 * time.Minute)
+
 	ce := events.CloudEvent{
 		Id:          "id",
 		Source:      "wandalorian",
@@ -117,6 +149,18 @@ func TestFromEvent(t *testing.T) {
 		Type:        "FactsGatheringRequested",
 		Data: &events.CloudEvent_ProtoData{
 			ProtoData: data,
+		},
+		Attributes: map[string]*events.CloudEventAttributeValue{
+			"time": {
+				Attr: &events.CloudEventAttributeValue_CeTimestamp{
+					CeTimestamp: timestamppb.New(now),
+				},
+			},
+			"expiration": {
+				Attr: &events.CloudEventAttributeValue_CeTimestamp{
+					CeTimestamp: timestamppb.New(expiration),
+				},
+			},
 		},
 	}
 
@@ -133,4 +177,160 @@ func TestFromEvent(t *testing.T) {
 	assert.EqualValues(t, event.GetExecutionId(), decodedEvent.GetExecutionId())
 	assert.EqualValues(t, event.GetGroupId(), decodedEvent.GetGroupId())
 	assert.EqualValues(t, event.Targets[0].String(), event.Targets[0].String())
+}
+
+func TestFromEventExpiredEventError(t *testing.T) {
+	event := events.FactsGatheringRequested{
+		ExecutionId: "exe",
+		GroupId:     "group_1",
+		Targets: []*events.FactsGatheringRequestedTarget{
+			{
+				AgentId: "agent_1",
+				FactRequests: []*events.FactRequest{
+					{
+						CheckId:  "check_1",
+						Name:     "test fact",
+						Gatherer: "factone",
+						Argument: "arg",
+					},
+				},
+			},
+		},
+	}
+
+	data, err := anypb.New(&event)
+
+	eventCreated := time.Now().Add(-2 * time.Minute)
+	expiration := eventCreated.Add(20 * time.Second)
+
+	assert.NoError(t, err)
+	ce := events.CloudEvent{
+		Id:          "id",
+		Source:      "wandalorian",
+		SpecVersion: "1.0",
+		Type:        "FactsGatheringRequested",
+		Data: &events.CloudEvent_ProtoData{
+			ProtoData: data,
+		},
+		Attributes: map[string]*events.CloudEventAttributeValue{
+			"time": {
+				Attr: &events.CloudEventAttributeValue_CeTimestamp{
+					CeTimestamp: timestamppb.New(eventCreated),
+				},
+			},
+			"expiration": {
+				Attr: &events.CloudEventAttributeValue_CeTimestamp{
+					CeTimestamp: timestamppb.New(expiration),
+				},
+			},
+		},
+	}
+
+	var decodedEvent events.FactsGatheringRequested
+
+	rawEvent, err := proto.Marshal(&ce)
+	assert.NoError(t, err)
+	err = events.FromEvent(rawEvent, &decodedEvent)
+	assert.ErrorIs(t, err, events.ErrEventExpired)
+}
+
+func TestFromEventNoExpirationSetError(t *testing.T) {
+	event := events.FactsGatheringRequested{
+		ExecutionId: "exe",
+		GroupId:     "group_1",
+		Targets: []*events.FactsGatheringRequestedTarget{
+			{
+				AgentId: "agent_1",
+				FactRequests: []*events.FactRequest{
+					{
+						CheckId:  "check_1",
+						Name:     "test fact",
+						Gatherer: "factone",
+						Argument: "arg",
+					},
+				},
+			},
+		},
+	}
+
+	data, err := anypb.New(&event)
+
+	eventCreated := time.Now().Add(-2 * time.Minute)
+
+	assert.NoError(t, err)
+	ce := events.CloudEvent{
+		Id:          "id",
+		Source:      "wandalorian",
+		SpecVersion: "1.0",
+		Type:        "FactsGatheringRequested",
+		Data: &events.CloudEvent_ProtoData{
+			ProtoData: data,
+		},
+		Attributes: map[string]*events.CloudEventAttributeValue{
+			"time": {
+				Attr: &events.CloudEventAttributeValue_CeTimestamp{
+					CeTimestamp: timestamppb.New(eventCreated),
+				},
+			},
+		},
+	}
+
+	var decodedEvent events.FactsGatheringRequested
+
+	rawEvent, err := proto.Marshal(&ce)
+	assert.NoError(t, err)
+	err = events.FromEvent(rawEvent, &decodedEvent)
+	assert.ErrorIs(t, err, events.ErrExpirationNotFound)
+}
+
+func TestFromEventExpirationMalformedError(t *testing.T) {
+	event := events.FactsGatheringRequested{
+		ExecutionId: "exe",
+		GroupId:     "group_1",
+		Targets: []*events.FactsGatheringRequestedTarget{
+			{
+				AgentId: "agent_1",
+				FactRequests: []*events.FactRequest{
+					{
+						CheckId:  "check_1",
+						Name:     "test fact",
+						Gatherer: "factone",
+						Argument: "arg",
+					},
+				},
+			},
+		},
+	}
+
+	data, err := anypb.New(&event)
+
+	eventCreated := time.Now().Add(-2 * time.Minute)
+
+	assert.NoError(t, err)
+	ce := events.CloudEvent{
+		Id:          "id",
+		Source:      "wandalorian",
+		SpecVersion: "1.0",
+		Type:        "FactsGatheringRequested",
+		Data: &events.CloudEvent_ProtoData{
+			ProtoData: data,
+		},
+		Attributes: map[string]*events.CloudEventAttributeValue{
+			"time": {
+				Attr: &events.CloudEventAttributeValue_CeTimestamp{
+					CeTimestamp: timestamppb.New(eventCreated),
+				},
+			},
+			"expiration": {
+				Attr: nil,
+			},
+		},
+	}
+
+	var decodedEvent events.FactsGatheringRequested
+
+	rawEvent, err := proto.Marshal(&ce)
+	assert.NoError(t, err)
+	err = events.FromEvent(rawEvent, &decodedEvent)
+	assert.ErrorIs(t, err, events.ErrExpirationAttributeMalformed)
 }


### PR DESCRIPTION
This PR adds the support for event expiration.

This features helps to mitigate replay attacks against our messages.

Both the facades, the elixir and the golang one, accept as an option an expiration time for the message, when not provided a default 5 minutes expiration is set.

The expiration is checked in the decoding phase of events, raising errors when expiration is not set, malformed or simply the message is expired.

By default the checking of expiration of the messages is not enabled for backward compatibility issues (Especially on the agent) and should be explicitly enabled in the from event functions using appropriate options

Added tests to both the libraries.