### PR TITLE
Fix spacing

### DIFF
--- a/go/pkg/events/check_custom_value.pb.go
+++ b/go/pkg/events/check_custom_value.pb.go
@@ -27,7 +27,6 @@ type CheckCustomValue struct {
 
 	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
 	// Types that are assignable to Value:
-	//
 	//	*CheckCustomValue_StringValue
 	//	*CheckCustomValue_IntValue
 	//	*CheckCustomValue_BoolValue


### PR DESCRIPTION
My local `make` command seems to add some spacing detected as changes by the ci 🤷 

We could consider aligning the golang version used in the CI with what defined in `.tool-versions` as in this PR https://github.com/trento-project/contracts/pull/95 but we'd need to regenerate contracts and temporarily have a broken CI.