### PR TITLE
Add support for attributes encoding/decoding

### DIFF
--- a/elixir/lib/contracts.ex
+++ b/elixir/lib/contracts.ex
@@ -129,7 +129,7 @@ defmodule Trento.Contracts do
 
   defp encode_additional_attributes(attributes) do
     Enum.into(attributes, %{}, fn {key, {type, value}} ->
-      {Atom.to_string(key), %CloudEvents.CloudEventAttributeValue{attr: {type, value}}}
+      {key, %CloudEvents.CloudEventAttributeValue{attr: {type, value}}}
     end)
   end
 

--- a/elixir/lib/contracts.ex
+++ b/elixir/lib/contracts.ex
@@ -34,8 +34,17 @@ defmodule Trento.Contracts do
         DateTime.add(time, @default_expiration_window_minutes, :minute)
       )
 
+    additional_attributes = Keyword.get(opts, :additional_attributes, %{})
+
     time_attr = %Google.Protobuf.Timestamp{seconds: time |> DateTime.to_unix()}
     expiration_attr = %Google.Protobuf.Timestamp{seconds: expiration |> DateTime.to_unix()}
+
+    default_attributes = %{
+      "time" => %CloudEvents.CloudEventAttributeValue{attr: {:ce_timestamp, time_attr}},
+      "expiration" => %CloudEvents.CloudEventAttributeValue{
+        attr: {:ce_timestamp, expiration_attr}
+      }
+    }
 
     data = Protobuf.Encoder.encode(struct)
 
@@ -44,12 +53,11 @@ defmodule Trento.Contracts do
       spec_version: "1.0",
       type: get_type(mod),
       id: id,
-      attributes: %{
-        "time" => %CloudEvents.CloudEventAttributeValue{attr: {:ce_timestamp, time_attr}},
-        "expiration" => %CloudEvents.CloudEventAttributeValue{
-          attr: {:ce_timestamp, expiration_attr}
-        }
-      },
+      attributes:
+        Map.merge(
+          default_attributes,
+          encode_additional_attributes(additional_attributes)
+        ),
       source: source
     }
 
@@ -63,7 +71,7 @@ defmodule Trento.Contracts do
           {:ok, struct()}
           | {:error, :decoding_error}
           | {:error, :invalid_envelope}
-          | {:error, :event_not_found}
+          | {:error, :unknown_event}
   def from_event(value, opts \\ []) do
     validate_expiration =
       Keyword.get(
@@ -72,21 +80,22 @@ defmodule Trento.Contracts do
         false
       )
 
-    try do
-      case decode_and_validate(value, validate_expiration) do
-        {:ok, event} ->
-          {:ok, event}
+    case decode_and_validate(value, validate_expiration) do
+      {:ok, event} ->
+        {:ok, event}
 
-        {:error, reason} ->
-          Logger.error("Invalid trento event: #{inspect(reason)}")
+      {:error, reason} ->
+        Logger.error("Invalid trento event: #{inspect(reason)}")
 
-          {:error, reason}
-      end
-    rescue
-      error ->
-        Logger.error("Decoding error: #{inspect(error)}")
+        {:error, reason}
+    end
+  end
 
-        {:error, :decoding_error}
+  @spec attributes_from_event(binary()) ::
+          {:ok, map()} | {:error, :invalid_envelope | :decoding_error}
+  def attributes_from_event(event) do
+    with {:ok, _, attributes, _} <- extract_event(event) do
+      {:ok, decode_attributes(attributes)}
     end
   end
 
@@ -111,17 +120,32 @@ defmodule Trento.Contracts do
         Logger.error("Invalid cloud event: #{inspect(invalid_event)}")
         {:error, :invalid_envelope}
     end
+  rescue
+    error ->
+      Logger.error("Decoding error: #{inspect(error)}")
+
+      {:error, :decoding_error}
+  end
+
+  defp encode_additional_attributes(attributes) do
+    Enum.into(attributes, %{}, fn {key, {type, value}} ->
+      {Atom.to_string(key), %CloudEvents.CloudEventAttributeValue{attr: {type, value}}}
+    end)
+  end
+
+  defp decode_attributes(attributes) do
+    Enum.into(attributes, %{}, fn {key, %CloudEvents.CloudEventAttributeValue{attr: {_, value}}} ->
+      {key, value}
+    end)
   end
 
   defp decode_trento_event(type, data) do
-    try do
-      module_name = Macro.camelize(type)
-      module = Module.safe_concat([module_name])
+    module_name = Macro.camelize(type)
+    module = Module.safe_concat([module_name])
 
-      {:ok, module.decode(data)}
-    rescue
-      ArgumentError -> {:error, :unknown_event}
-    end
+    {:ok, module.decode(data)}
+  rescue
+    ArgumentError -> {:error, :unknown_event}
   end
 
   defp get_type(mod) do

--- a/elixir/lib/contracts.ex
+++ b/elixir/lib/contracts.ex
@@ -134,8 +134,8 @@ defmodule Trento.Contracts do
   end
 
   defp decode_attributes(attributes) do
-    Enum.into(attributes, %{}, fn {key, %CloudEvents.CloudEventAttributeValue{attr: {_, value}}} ->
-      {key, value}
+    Enum.into(attributes, %{}, fn {key, %CloudEvents.CloudEventAttributeValue{attr: attr}} ->
+      {key, attr}
     end)
   end
 

--- a/elixir/test/contracts_test.exs
+++ b/elixir/test/contracts_test.exs
@@ -102,14 +102,11 @@ defmodule Trento.ContractsTest do
       expiration_attr = %Google.Protobuf.Timestamp{seconds: expiration |> DateTime.to_unix()}
       user_id = 1
 
-      default_attributes = %{
+      attributes = %{
         "time" => %CloudEvents.CloudEventAttributeValue{attr: {:ce_timestamp, time_attr}},
         "expiration" => %CloudEvents.CloudEventAttributeValue{
           attr: {:ce_timestamp, expiration_attr}
-        }
-      }
-
-      additional_attributes = %{
+        },
         "user_id" => %CloudEvents.CloudEventAttributeValue{attr: {:ce_integer, user_id}},
         "foo" => %CloudEvents.CloudEventAttributeValue{attr: {:ce_string, "bar"}},
         "baz" => %CloudEvents.CloudEventAttributeValue{attr: {:ce_bytes, <<1, 2, 3>>}},
@@ -123,42 +120,27 @@ defmodule Trento.ContractsTest do
         }
       }
 
-      attributes_scenarios = [
-        %{
-          name: "default attributes",
-          attributes: default_attributes,
-          expected_attributes: %{
-            "time" => time_attr,
-            "expiration" => expiration_attr
-          }
-        },
-        %{
-          name: "with additional attributes",
-          attributes: Map.merge(default_attributes, additional_attributes),
-          expected_attributes: %{
-            "time" => time_attr,
-            "expiration" => expiration_attr,
-            "user_id" => 1,
-            "foo" => "bar",
-            "baz" => <<1, 2, 3>>,
-            "qux" => true,
-            "quux" => "https://example.com",
-            "corge" => "https://example.com",
-            "grault" => %Google.Protobuf.Timestamp{seconds: 123_456_789}
-          }
-        }
-      ]
+      expected_attributes = %{
+        "time" => time_attr,
+        "expiration" => expiration_attr,
+        "time" => time_attr,
+        "expiration" => expiration_attr,
+        "user_id" => 1,
+        "foo" => "bar",
+        "baz" => <<1, 2, 3>>,
+        "qux" => true,
+        "quux" => "https://example.com",
+        "corge" => "https://example.com",
+        "grault" => %Google.Protobuf.Timestamp{seconds: 123_456_789}
+      }
 
-      for %{attributes: attributes, expected_attributes: expected_attributes} <-
-            attributes_scenarios do
-        encoded_cloudevent =
-          UUID.uuid4()
-          |> build_cloud_event(event, attributes)
-          |> CloudEvent.encode()
+      encoded_cloudevent =
+        UUID.uuid4()
+        |> build_cloud_event(event, attributes)
+        |> CloudEvent.encode()
 
-        assert {:ok, ^expected_attributes} =
-                 Trento.Contracts.attributes_from_event(encoded_cloudevent)
-      end
+      assert {:ok, ^expected_attributes} =
+               Trento.Contracts.attributes_from_event(encoded_cloudevent)
     end
 
     test "should not be able to decode attributes" do

--- a/elixir/test/contracts_test.exs
+++ b/elixir/test/contracts_test.exs
@@ -121,17 +121,15 @@ defmodule Trento.ContractsTest do
       }
 
       expected_attributes = %{
-        "time" => time_attr,
-        "expiration" => expiration_attr,
-        "time" => time_attr,
-        "expiration" => expiration_attr,
-        "user_id" => 1,
-        "foo" => "bar",
-        "baz" => <<1, 2, 3>>,
-        "qux" => true,
-        "quux" => "https://example.com",
-        "corge" => "https://example.com",
-        "grault" => %Google.Protobuf.Timestamp{seconds: 123_456_789}
+        "time" => {:ce_timestamp, time_attr},
+        "expiration" => {:ce_timestamp, expiration_attr},
+        "user_id" => {:ce_integer, user_id},
+        "foo" => {:ce_string, "bar"},
+        "baz" => {:ce_bytes, <<1, 2, 3>>},
+        "qux" => {:ce_boolean, true},
+        "quux" => {:ce_uri, "https://example.com"},
+        "corge" => {:ce_uri_ref, "https://example.com"},
+        "grault" => {:ce_timestamp, %Google.Protobuf.Timestamp{seconds: 123_456_789}}
       }
 
       encoded_cloudevent =

--- a/elixir/test/contracts_test.exs
+++ b/elixir/test/contracts_test.exs
@@ -255,13 +255,13 @@ defmodule Trento.ContractsTest do
                  time: time,
                  expiration: expiration,
                  additional_attributes: %{
-                   user_id: {:ce_integer, user_id},
-                   foo: {:ce_string, "bar"},
-                   baz: {:ce_bytes, <<1, 2, 3>>},
-                   qux: {:ce_boolean, true},
-                   quux: {:ce_uri, "https://example.com"},
-                   corge: {:ce_uri_ref, "https://example.com"},
-                   grault: {:ce_timestamp, %Google.Protobuf.Timestamp{seconds: 123_456_789}}
+                   "user_id" => {:ce_integer, user_id},
+                   "foo" => {:ce_string, "bar"},
+                   "baz" => {:ce_bytes, <<1, 2, 3>>},
+                   "qux" => {:ce_boolean, true},
+                   "quux" => {:ce_uri, "https://example.com"},
+                   "corge" => {:ce_uri_ref, "https://example.com"},
+                   "grault" => {:ce_timestamp, %Google.Protobuf.Timestamp{seconds: 123_456_789}}
                  }
                )
     end

--- a/elixir/test/contracts_test.exs
+++ b/elixir/test/contracts_test.exs
@@ -4,23 +4,6 @@ defmodule Trento.ContractsTest do
 
   alias CloudEvents.CloudEvent
 
-  def build_cloud_event(id, event, attributes) do
-    %CloudEvent{
-      data:
-        {:proto_data,
-         %Google.Protobuf.Any{
-           __unknown_fields__: [],
-           type_url: "Test.Event",
-           value: Test.Event.encode(event)
-         }},
-      id: id,
-      source: "wandalorian",
-      spec_version: "1.0",
-      type: "Test.Event",
-      attributes: attributes
-    }
-  end
-
   describe "event decoding" do
     test "should decode to the right struct when no errors are detected in the event payload" do
       event_id = UUID.uuid4()
@@ -310,5 +293,22 @@ defmodule Trento.ContractsTest do
                  }
                )
     end
+  end
+
+  defp build_cloud_event(id, event, attributes) do
+    %CloudEvent{
+      data:
+        {:proto_data,
+         %Google.Protobuf.Any{
+           __unknown_fields__: [],
+           type_url: "Test.Event",
+           value: Test.Event.encode(event)
+         }},
+      id: id,
+      source: "wandalorian",
+      spec_version: "1.0",
+      type: "Test.Event",
+      attributes: attributes
+    }
   end
 end

--- a/elixir/test/contracts_test.exs
+++ b/elixir/test/contracts_test.exs
@@ -243,38 +243,28 @@ defmodule Trento.ContractsTest do
       expiration_attr = %Google.Protobuf.Timestamp{seconds: expiration |> DateTime.to_unix()}
       user_id = 1
 
-      cloudevent = %CloudEvent{
-        data:
-          {:proto_data,
-           %Google.Protobuf.Any{
-             __unknown_fields__: [],
-             type_url: "Test.Event",
-             value: Test.Event.encode(event)
-           }},
-        id: cloudevent_id,
-        source: "wandalorian",
-        spec_version: "1.0",
-        type: "Test.Event",
-        attributes: %{
-          "time" => %CloudEvents.CloudEventAttributeValue{attr: {:ce_timestamp, time_attr}},
-          "expiration" => %CloudEvents.CloudEventAttributeValue{
-            attr: {:ce_timestamp, expiration_attr}
-          },
-          "user_id" => %CloudEvents.CloudEventAttributeValue{attr: {:ce_integer, user_id}},
-          "foo" => %CloudEvents.CloudEventAttributeValue{attr: {:ce_string, "bar"}},
-          "baz" => %CloudEvents.CloudEventAttributeValue{attr: {:ce_bytes, <<1, 2, 3>>}},
-          "qux" => %CloudEvents.CloudEventAttributeValue{attr: {:ce_boolean, true}},
-          "quux" => %CloudEvents.CloudEventAttributeValue{attr: {:ce_uri, "https://example.com"}},
-          "corge" => %CloudEvents.CloudEventAttributeValue{
-            attr: {:ce_uri_ref, "https://example.com"}
-          },
-          "grault" => %CloudEvents.CloudEventAttributeValue{
-            attr: {:ce_timestamp, %Google.Protobuf.Timestamp{seconds: 123_456_789}}
-          }
+      attributes = %{
+        "time" => %CloudEvents.CloudEventAttributeValue{attr: {:ce_timestamp, time_attr}},
+        "expiration" => %CloudEvents.CloudEventAttributeValue{
+          attr: {:ce_timestamp, expiration_attr}
+        },
+        "user_id" => %CloudEvents.CloudEventAttributeValue{attr: {:ce_integer, user_id}},
+        "foo" => %CloudEvents.CloudEventAttributeValue{attr: {:ce_string, "bar"}},
+        "baz" => %CloudEvents.CloudEventAttributeValue{attr: {:ce_bytes, <<1, 2, 3>>}},
+        "qux" => %CloudEvents.CloudEventAttributeValue{attr: {:ce_boolean, true}},
+        "quux" => %CloudEvents.CloudEventAttributeValue{attr: {:ce_uri, "https://example.com"}},
+        "corge" => %CloudEvents.CloudEventAttributeValue{
+          attr: {:ce_uri_ref, "https://example.com"}
+        },
+        "grault" => %CloudEvents.CloudEventAttributeValue{
+          attr: {:ce_timestamp, %Google.Protobuf.Timestamp{seconds: 123_456_789}}
         }
       }
 
-      encoded_cloudevent = CloudEvent.encode(cloudevent)
+      encoded_cloudevent =
+        cloudevent_id
+        |> build_cloud_event(event, attributes)
+        |> CloudEvent.encode()
 
       assert encoded_cloudevent ==
                Trento.Contracts.to_event(event,


### PR DESCRIPTION
This PR allows to enrich the cloud events attributes with a `user_id` entry, if provided.
- a new`attributes_from_event` function is exposed
- some small refactoring to make dialyzer happy

Notes:
- golang contracts remain untouched because at the moment we don't need this enrichment
- web and wanda need to be adjusted to consider the third element in the returned tuple (unless we add a different function to return decoded event with attributes)

usage in web - comsuming/decoding https://github.com/trento-project/web/pull/3440
usage in wanda - publishing/encoding https://github.com/trento-project/wanda/pull/604